### PR TITLE
BAU: Update libraries and remove Google dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,10 @@ subprojects {
     }
 
     dependencies {
-        common  "uk.gov.verify:saml-utils:$opensaml_version-65",
+        common  "uk.gov.verify:saml-utils:$opensaml_version-70",
                 "org.opensaml:opensaml-core:$opensaml_version",
-                'com.google.guava:guava:18.0',
                 'joda-time:joda-time:2.9',
-                'javax.inject:javax.inject:1',
-                'com.google.inject:guice:4.0'
+                'javax.inject:javax.inject:1'
 
         test_deps "uk.gov.verify:saml-test-utils:$opensaml_version-43",
                 'commons-codec:commons-codec:1.10'

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/PrivateKeyStoreFactory.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/PrivateKeyStoreFactory.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.saml.idp.test;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.codec.binary.Base64;
 import uk.gov.ida.common.shared.security.PrivateKeyFactory;
 import uk.gov.ida.common.shared.security.PrivateKeyStore;
@@ -8,12 +7,15 @@ import uk.gov.ida.saml.core.test.TestCertificateStrings;
 
 import java.security.PrivateKey;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PrivateKeyStoreFactory {
     public PrivateKeyStore create(String entityId) {
         PrivateKey privateSigningKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(TestCertificateStrings.PRIVATE_SIGNING_KEYS.get(entityId)));
         List<String> encryptionKeyStrings = TestCertificateStrings.PRIVATE_ENCRYPTION_KEYS.get(entityId);
-        List<PrivateKey> privateEncryptionKeys = Lists.transform(encryptionKeyStrings, input -> new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(input)));
+        List<PrivateKey> privateEncryptionKeys = encryptionKeyStrings.stream()
+                .map(input -> new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(input)))
+                .collect(Collectors.toList());
         return new PrivateKeyStore(privateSigningKey, privateEncryptionKeys);
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/IPAddressAttributeBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/IPAddressAttributeBuilder.java
@@ -1,18 +1,16 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.Attribute;
 import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.extensions.IPAddress;
 
-import static com.google.common.base.Optional.fromNullable;
-
 public class IPAddressAttributeBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
 
-    private Optional<String> value = fromNullable("1.2.3.4");
+    private Optional<String> value = Optional.ofNullable("1.2.3.4");
 
     public static IPAddressAttributeBuilder anIPAddress() {
         return new IPAddressAttributeBuilder();
@@ -24,7 +22,7 @@ public class IPAddressAttributeBuilder {
         ipAddressAttribute.setFriendlyName(IdaConstants.Attributes_1_1.IPAddress.FRIENDLY_NAME);
         ipAddressAttribute.setName(IdaConstants.Attributes_1_1.IPAddress.NAME);
 
-        IPAddress ipAddressAttributeValue = openSamlXmlObjectFactory.createIPAddressAttributeValue(value.orNull());
+        IPAddress ipAddressAttributeValue = openSamlXmlObjectFactory.createIPAddressAttributeValue(value.orElse(null));
 
         ipAddressAttribute.getAttributeValues().add(ipAddressAttributeValue);
 
@@ -32,7 +30,7 @@ public class IPAddressAttributeBuilder {
     }
 
     public IPAddressAttributeBuilder withValue(String name) {
-        this.value = fromNullable(name);
+        this.value = Optional.ofNullable(name);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/IdentityProviderAssertionBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/IdentityProviderAssertionBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.saml.core.domain.AssertionRestrictions;
 import uk.gov.ida.saml.core.domain.IdentityProviderAssertion;
@@ -8,10 +7,8 @@ import uk.gov.ida.saml.core.domain.PersistentId;
 import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 
+import java.util.Optional;
 import java.util.UUID;
-
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
 
 public class IdentityProviderAssertionBuilder {
 
@@ -20,8 +17,8 @@ public class IdentityProviderAssertionBuilder {
     private DateTime issueInstant = DateTime.now();
     private PersistentId persistentId = PersistentIdBuilder.aPersistentId().build();
     private AssertionRestrictions assertionRestrictions = AssertionRestrictionsBuilder.anAssertionRestrictions().build();
-    private Optional<MatchingDataset> matchingDataset = absent();
-    private Optional<IdentityProviderAuthnStatement> authnStatement = absent();
+    private Optional<MatchingDataset> matchingDataset = Optional.empty();
+    private Optional<IdentityProviderAuthnStatement> authnStatement = Optional.empty();
 
     public static IdentityProviderAssertionBuilder anIdentityProviderAssertion() {
         return new IdentityProviderAssertionBuilder();
@@ -64,12 +61,12 @@ public class IdentityProviderAssertionBuilder {
     }
 
     public IdentityProviderAssertionBuilder withAuthnStatement(IdentityProviderAuthnStatement idaAuthnStatement) {
-        this.authnStatement = fromNullable(idaAuthnStatement);
+        this.authnStatement = Optional.ofNullable(idaAuthnStatement);
         return this;
     }
 
     public IdentityProviderAssertionBuilder withMatchingDataset(MatchingDataset matchingDataset) {
-        this.matchingDataset = fromNullable(matchingDataset);
+        this.matchingDataset = Optional.ofNullable(matchingDataset);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/IssuerBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/IssuerBuilder.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.Issuer;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
@@ -8,7 +8,7 @@ import uk.gov.ida.saml.core.test.TestCertificateStrings;
 public class IssuerBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<String> issuerId = Optional.fromNullable(TestCertificateStrings.TEST_ENTITY_ID);
+    private Optional<String> issuerId = Optional.ofNullable(TestCertificateStrings.TEST_ENTITY_ID);
     private String format = null;
 
     public static IssuerBuilder anIssuer() {
@@ -17,7 +17,7 @@ public class IssuerBuilder {
 
     public Issuer build() {
 
-        Issuer issuer = openSamlXmlObjectFactory.createIssuer(issuerId.orNull());
+        Issuer issuer = openSamlXmlObjectFactory.createIssuer(issuerId.orElse(null));
 
         issuer.setFormat(format);
 
@@ -25,7 +25,7 @@ public class IssuerBuilder {
     }
 
     public IssuerBuilder withIssuerId(String issuerId) {
-        this.issuerId = Optional.fromNullable(issuerId);
+        this.issuerId = Optional.ofNullable(issuerId);
         return this;
     }
 

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/NameIdBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/NameIdBuilder.java
@@ -1,20 +1,17 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.NameIDType;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
-
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
 
 public class NameIdBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
     private String value;
-    private Optional<String> format = fromNullable(NameIDType.PERSISTENT);
-    private Optional<String> nameQualifier = absent();
-    private Optional<String> spNameQualifier = absent();
+    private Optional<String> format = Optional.ofNullable(NameIDType.PERSISTENT);
+    private Optional<String> nameQualifier = Optional.empty();
+    private Optional<String> spNameQualifier = Optional.empty();
 
     public static NameIdBuilder aNameId() {
         return new NameIdBuilder();
@@ -45,17 +42,17 @@ public class NameIdBuilder {
     }
 
     public NameIdBuilder withFormat(String format) {
-        this.format = fromNullable(format);
+        this.format = Optional.ofNullable(format);
         return this;
     }
 
     public NameIdBuilder withNameQualifier(String nameQualifier) {
-        this.nameQualifier = fromNullable(nameQualifier);
+        this.nameQualifier = Optional.ofNullable(nameQualifier);
         return this;
     }
 
     public NameIdBuilder withSpNameQualifier(String spNameQualifier) {
-        this.spNameQualifier = fromNullable(spNameQualifier);
+        this.spNameQualifier = Optional.ofNullable(spNameQualifier);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/NameIdPolicyBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/NameIdPolicyBuilder.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.saml.saml2.core.NameIDType;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
@@ -8,7 +8,7 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 public class NameIdPolicyBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<String> format = Optional.fromNullable(NameIDType.PERSISTENT);
+    private Optional<String> format = Optional.ofNullable(NameIDType.PERSISTENT);
 
     public static NameIdPolicyBuilder aNameIdPolicy() {
         return new NameIdPolicyBuilder();
@@ -26,7 +26,7 @@ public class NameIdPolicyBuilder {
     }
 
     public NameIdPolicyBuilder withFormat(String format) {
-        this.format = Optional.fromNullable(format);
+        this.format = Optional.ofNullable(format);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SimpleStringAttributeBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SimpleStringAttributeBuilder.java
@@ -1,18 +1,15 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.Attribute;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.extensions.StringBasedMdsAttributeValue;
 
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
-
 public class SimpleStringAttributeBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<String> name = Optional.absent();
-    private Optional<String> simpleStringValue = absent();
+    private Optional<String> name = Optional.empty();
+    private Optional<String> simpleStringValue = Optional.empty();
 
     public static SimpleStringAttributeBuilder aSimpleStringAttribute() {
         return new SimpleStringAttributeBuilder();
@@ -33,12 +30,12 @@ public class SimpleStringAttributeBuilder {
     }
 
     public SimpleStringAttributeBuilder withName(String name) {
-        this.name = fromNullable(name);
+        this.name = Optional.ofNullable(name);
         return this;
     }
 
     public SimpleStringAttributeBuilder withSimpleStringValue(String value){
-        this.simpleStringValue = fromNullable(value);
+        this.simpleStringValue = Optional.ofNullable(value);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/StatusBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/StatusBuilder.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.StatusMessage;
@@ -9,8 +9,8 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 public class StatusBuilder {
 
     private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<StatusCode> statusCode = Optional.fromNullable(StatusCodeBuilder.aStatusCode().build());
-    private Optional<StatusMessage> message = Optional.absent();
+    private Optional<StatusCode> statusCode = Optional.ofNullable(StatusCodeBuilder.aStatusCode().build());
+    private Optional<StatusMessage> message = Optional.empty();
 
 
     public static StatusBuilder aStatus() {
@@ -32,12 +32,12 @@ public class StatusBuilder {
     }
 
     public StatusBuilder withStatusCode(StatusCode statusCode) {
-        this.statusCode = Optional.fromNullable(statusCode);
+        this.statusCode = Optional.ofNullable(statusCode);
         return this;
     }
 
     public StatusBuilder withMessage(StatusMessage message) {
-        this.message = Optional.fromNullable(message);
+        this.message = Optional.ofNullable(message);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/StatusCodeBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/StatusCodeBuilder.java
@@ -1,18 +1,15 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.StatusCode;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.domain.SamlStatusCode;
 
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
-
 public class StatusCodeBuilder {
 
     private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<String> value = fromNullable(StatusCode.SUCCESS);
-    private Optional<StatusCode> subStatus = absent();
+    private Optional<String> value = Optional.ofNullable(StatusCode.SUCCESS);
+    private Optional<StatusCode> subStatus = Optional.empty();
 
     public static StatusCodeBuilder aStatusCode() {
         return new StatusCodeBuilder();
@@ -33,12 +30,12 @@ public class StatusCodeBuilder {
     }
 
     public StatusCodeBuilder withValue(String value) {
-        this.value = fromNullable(value);
+        this.value = Optional.ofNullable(value);
         return this;
     }
 
     public StatusCodeBuilder withSubStatusCode(StatusCode subStatusCode){
-        this.subStatus = fromNullable(subStatusCode);
+        this.subStatus = Optional.ofNullable(subStatusCode);
         return this;
     }
 

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SubjectBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SubjectBuilder.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
@@ -9,13 +9,12 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Optional.fromNullable;
 import static uk.gov.ida.saml.idp.test.builders.NameIdBuilder.aNameId;
 
 public class SubjectBuilder {
 
     private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<NameID> nameIdValue = fromNullable(aNameId().build());
+    private Optional<NameID> nameIdValue = Optional.ofNullable(aNameId().build());
     private List<SubjectConfirmation> subjectConfirmations = new ArrayList<>();
     private boolean shouldAddDefaultSubjectConfirmation = true;
 
@@ -39,7 +38,7 @@ public class SubjectBuilder {
     }
 
     public SubjectBuilder withNameId(NameID nameId) {
-        this.nameIdValue = fromNullable(nameId);
+        this.nameIdValue = Optional.ofNullable(nameId);
         return this;
     }
 

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SubjectConfirmationBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SubjectConfirmationBuilder.java
@@ -1,17 +1,15 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 
-import static com.google.common.base.Optional.fromNullable;
-
 public class SubjectConfirmationBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<String> method = fromNullable(SubjectConfirmation.METHOD_BEARER);
-    private Optional<SubjectConfirmationData> subjectConfirmationData = fromNullable(SubjectConfirmationDataBuilder.aSubjectConfirmationData().build());
+    private Optional<String> method = Optional.ofNullable(SubjectConfirmation.METHOD_BEARER);
+    private Optional<SubjectConfirmationData> subjectConfirmationData = Optional.ofNullable(SubjectConfirmationDataBuilder.aSubjectConfirmationData().build());
 
     public static SubjectConfirmationBuilder aSubjectConfirmation() {
         return new SubjectConfirmationBuilder();
@@ -32,12 +30,12 @@ public class SubjectConfirmationBuilder {
     }
 
     public SubjectConfirmationBuilder withMethod(String method) {
-        this.method = fromNullable(method);
+        this.method = Optional.ofNullable(method);
         return this;
     }
 
     public SubjectConfirmationBuilder withSubjectConfirmationData(SubjectConfirmationData subjectConfirmationData) {
-        this.subjectConfirmationData = fromNullable(subjectConfirmationData);
+        this.subjectConfirmationData = Optional.ofNullable(subjectConfirmationData);
         return this;
     }
 }

--- a/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SubjectConfirmationDataBuilder.java
+++ b/stub-idp-saml-test/src/main/java/uk/gov/ida/saml/idp/test/builders/SubjectConfirmationDataBuilder.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.idp.test.builders;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.joda.time.DateTime;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
@@ -12,19 +12,16 @@ import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
-
 public class SubjectConfirmationDataBuilder {
 
     public static final int NOT_ON_OR_AFTER_DEFAULT_PERIOD = 15;
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private Optional<String> recipient = fromNullable(TestEntityIds.HUB_ENTITY_ID);
-    private Optional<DateTime> notOnOrAfter = fromNullable(DateTime.now().plusMinutes(NOT_ON_OR_AFTER_DEFAULT_PERIOD));
-    private Optional<DateTime> notBefore = absent();
-    private Optional<String> address = absent();
-    private Optional<String> inResponseTo = fromNullable(ResponseBuilder.DEFAULT_REQUEST_ID);
+    private Optional<String> recipient = Optional.ofNullable(TestEntityIds.HUB_ENTITY_ID);
+    private Optional<DateTime> notOnOrAfter = Optional.ofNullable(DateTime.now().plusMinutes(NOT_ON_OR_AFTER_DEFAULT_PERIOD));
+    private Optional<DateTime> notBefore = Optional.empty();
+    private Optional<String> address = Optional.empty();
+    private Optional<String> inResponseTo = Optional.ofNullable(ResponseBuilder.DEFAULT_REQUEST_ID);
     private List<Assertion> assertions = new ArrayList<>();
     private List<EncryptedAssertion> encryptedAssertions = new ArrayList<>();
 
@@ -57,27 +54,27 @@ public class SubjectConfirmationDataBuilder {
     }
 
     public SubjectConfirmationDataBuilder withRecipient(String recipient) {
-        this.recipient = fromNullable(recipient);
+        this.recipient = Optional.ofNullable(recipient);
         return this;
     }
 
     public SubjectConfirmationDataBuilder withNotOnOrAfter(DateTime notOnOrAfter) {
-        this.notOnOrAfter = fromNullable(notOnOrAfter);
+        this.notOnOrAfter = Optional.ofNullable(notOnOrAfter);
         return this;
     }
 
     public SubjectConfirmationDataBuilder withNotBefore(DateTime notBefore) {
-        this.notBefore = fromNullable(notBefore);
+        this.notBefore = Optional.ofNullable(notBefore);
         return this;
     }
 
     public SubjectConfirmationDataBuilder withAddress(String address) {
-        this.address = fromNullable(address);
+        this.address = Optional.ofNullable(address);
         return this;
     }
 
     public SubjectConfirmationDataBuilder withInResponseTo(String inResponseTo) {
-        this.inResponseTo = fromNullable(inResponseTo);
+        this.inResponseTo = Optional.ofNullable(inResponseTo);
         return this;
     }
 

--- a/stub-idp-saml/src/main/java/uk/gov/ida/saml/idp/stub/domain/InboundResponseFromHub.java
+++ b/stub-idp-saml/src/main/java/uk/gov/ida/saml/idp/stub/domain/InboundResponseFromHub.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.idp.stub.domain;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.joda.time.DateTime;
 import org.opensaml.saml.saml2.core.Attribute;
 import uk.gov.ida.saml.core.domain.PersistentId;

--- a/stub-idp-saml/src/main/java/uk/gov/ida/saml/idp/stub/transformers/outbound/IdentityProviderAssertionToAssertionTransformer.java
+++ b/stub-idp-saml/src/main/java/uk/gov/ida/saml/idp/stub/transformers/outbound/IdentityProviderAssertionToAssertionTransformer.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.saml.idp.stub.transformers.outbound;
 
-import com.google.inject.Inject;
+import javax.inject.Inject;
+
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;

--- a/stub-idp-saml/src/main/java/uk/gov/ida/saml/idp/stub/transformers/outbound/IdentityProviderAuthnStatementToAuthnStatementTransformer.java
+++ b/stub-idp-saml/src/main/java/uk/gov/ida/saml/idp/stub/transformers/outbound/IdentityProviderAuthnStatementToAuthnStatementTransformer.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.saml.idp.stub.transformers.outbound;
 
-import com.google.inject.Inject;
+import javax.inject.Inject;
+
 import org.joda.time.DateTime;
 import org.opensaml.saml.saml2.core.AuthnContext;
 import org.opensaml.saml.saml2.core.AuthnStatement;

--- a/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/builders/IdentityProviderAuthnStatementBuilder.java
+++ b/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/builders/IdentityProviderAuthnStatementBuilder.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.idp.builders;
+
+import static uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement;
+import static uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement.createIdentityProviderFraudAuthnStatement;
+
+import java.util.Optional;
+
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.FraudAuthnDetails;
+import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
+import uk.gov.ida.saml.core.domain.IpAddress;
+
+public class IdentityProviderAuthnStatementBuilder {
+
+    private Optional<FraudAuthnDetails> fraudAuthnDetails = Optional.empty();
+    private AuthnContext authnContext = AuthnContext.LEVEL_1;
+    private Optional<IpAddress> userIpAddress = Optional.of(new IpAddress("9.9.8.8"));
+
+    public static IdentityProviderAuthnStatementBuilder anIdentityProviderAuthnStatement() {
+        return new IdentityProviderAuthnStatementBuilder();
+    }
+
+    public IdentityProviderAuthnStatement build() {
+        if (fraudAuthnDetails.isPresent()) {
+            return createIdentityProviderFraudAuthnStatement(fraudAuthnDetails.get(), userIpAddress.orElse(null));
+        }
+        return createIdentityProviderAuthnStatement(authnContext, userIpAddress.orElse(null));
+    }
+
+    public IdentityProviderAuthnStatementBuilder withAuthnContext(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+        return this;
+    }
+
+    public IdentityProviderAuthnStatementBuilder withFraudDetails(FraudAuthnDetails fraudDetails) {
+        this.fraudAuthnDetails = Optional.ofNullable(fraudDetails);
+        return this;
+    }
+
+    public IdentityProviderAuthnStatementBuilder withUserIpAddress(IpAddress userIpAddress) {
+        this.userIpAddress = Optional.ofNullable(userIpAddress);
+        return this;
+    }
+}

--- a/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/builders/MatchingDatasetBuilder.java
+++ b/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/builders/MatchingDatasetBuilder.java
@@ -1,0 +1,112 @@
+package uk.gov.ida.saml.idp.builders;
+
+import static java.util.Arrays.asList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+public class MatchingDatasetBuilder {
+
+    private List<SimpleMdsValue<String>> firstnames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> middleNames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+    private Optional<SimpleMdsValue<Gender>> gender = Optional.empty();
+    private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
+    private List<Address> currentAddresses = new ArrayList<>();
+    private List<Address> previousAddresses = new ArrayList<>();
+
+    public static MatchingDatasetBuilder aMatchingDataset() {
+        return new MatchingDatasetBuilder();
+    }
+
+    public static MatchingDatasetBuilder aFullyPopulatedMatchingDataset() {
+        final List<Address> currentAddressList = asList(new AddressFactory().create(asList("subject-address-line-1"), "subject-address-post-code", "internation-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        final List<Address> previousAddressList = asList(new AddressFactory().create(asList("previous-address-line-1"), "subject-address-post-code", "internation-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        final SimpleMdsValue<String> currentSurname = SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-currentSurname").withVerifiedStatus(true).build();
+        return aMatchingDataset()
+                .addFirstname(SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-firstname").withVerifiedStatus(true).build())
+                .addMiddleNames(SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-middlename").withVerifiedStatus(true).build())
+                .withSurnameHistory(asList(currentSurname))
+                .withGender(
+		                SimpleMdsValueBuilder.<Gender>aSimpleMdsValue().withValue(Gender.FEMALE).withVerifiedStatus(true).build())
+                .addDateOfBirth(SimpleMdsValueBuilder.<LocalDate>aSimpleMdsValue().withValue(LocalDate.parse("2000-02-09")).withVerifiedStatus(true).build())
+                .withCurrentAddresses(currentAddressList)
+                .withPreviousAddresses(previousAddressList);
+    }
+
+    public MatchingDataset build() {
+        return new MatchingDataset(firstnames, middleNames, surnames, gender, dateOfBirths, currentAddresses, previousAddresses);
+    }
+
+    public MatchingDatasetBuilder addFirstname(SimpleMdsValue<String> firstname) {
+        this.firstnames.add(firstname);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addMiddleNames(SimpleMdsValue<String> middleNames) {
+        this.middleNames.add(middleNames);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addSurname(SimpleMdsValue<String> surname) {
+        this.surnames.add(surname);
+        return this;
+    }
+
+    public MatchingDatasetBuilder withGender(SimpleMdsValue<Gender> gender) {
+        this.gender = Optional.ofNullable(gender);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addDateOfBirth(SimpleMdsValue<LocalDate> dateOfBirth) {
+        this.dateOfBirths.add(dateOfBirth);
+        return this;
+    }
+
+    public MatchingDatasetBuilder withCurrentAddresses(List<Address> currentAddresses) {
+        this.currentAddresses = currentAddresses;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withPreviousAddresses(List<Address> previousAddresses) {
+        this.previousAddresses = previousAddresses;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutFirstName() {
+        this.firstnames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutMiddleName() {
+        this.middleNames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutSurname() {
+        this.surnames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutDateOfBirth() {
+        this.dateOfBirths.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withSurnameHistory(
+            final List<SimpleMdsValue<String>> surnameHistory) {
+
+        this.surnames.clear();
+        this.surnames.addAll(surnameHistory);
+        return this;
+    }
+}

--- a/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/builders/SimpleMdsValueBuilder.java
+++ b/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/builders/SimpleMdsValueBuilder.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.saml.idp.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+public class SimpleMdsValueBuilder<T> {
+
+    private T value = null;
+
+    private DateTime from = DateTime.now().minusDays(5);
+    private DateTime to = DateTime.now().plusDays(5);
+    private boolean verified = false;
+
+    public static <T> SimpleMdsValueBuilder<T> aSimpleMdsValue() {
+        return new SimpleMdsValueBuilder<>();
+    }
+
+    public SimpleMdsValue<T> build() {
+        return new SimpleMdsValue<>(value, from, to, verified);
+    }
+
+    public SimpleMdsValueBuilder<T> withValue(T value) {
+        this.value = value;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withFrom(DateTime from) {
+        this.from = from;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withTo(DateTime to) {
+        this.to = to;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withVerifiedStatus(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+}

--- a/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/stub/tranformers/inbound/IdaAuthnRequestFromHubUnmarshallerTest.java
+++ b/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/stub/tranformers/inbound/IdaAuthnRequestFromHubUnmarshallerTest.java
@@ -18,7 +18,6 @@ import uk.gov.ida.saml.idp.stub.transformers.inbound.IdaAuthnRequestFromHubUnmar
 
 import java.util.Arrays;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration.EXACT;
@@ -44,7 +43,7 @@ public class IdaAuthnRequestFromHubUnmarshallerTest {
         when(authnRequest.getIssuer()).thenReturn(issuer);
         when(authnRequest.getRequestedAuthnContext()).thenReturn(requestedAuthnContext);
         when(authnRequest.getConditions()).thenReturn(conditions);
-        when(requestedAuthnContext.getAuthnContextClassRefs()).thenReturn(newArrayList(authnContextClassRef, authnContextClassRef));
+        when(requestedAuthnContext.getAuthnContextClassRefs()).thenReturn(Arrays.asList(authnContextClassRef, authnContextClassRef));
         when(requestedAuthnContext.getComparison()).thenReturn(EXACT);
         when(authnContextClassRef.getAuthnContextClassRef()).thenReturn(IdaAuthnContext.LEVEL_2_AUTHN_CTX, IdaAuthnContext.LEVEL_1_AUTHN_CTX);
     }

--- a/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/stub/tranformers/outbound/IdentityProviderAssertionToAssertionTransformerTest.java
+++ b/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/stub/tranformers/outbound/IdentityProviderAssertionToAssertionTransformerTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import uk.gov.ida.saml.core.domain.FraudAuthnDetails;
-import uk.gov.ida.saml.core.test.builders.MatchingDatasetBuilder;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.domain.Address;
 import uk.gov.ida.saml.core.domain.AddressFactory;
@@ -18,12 +17,14 @@ import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.domain.Gender;
 import uk.gov.ida.saml.core.domain.IdentityProviderAssertion;
 import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
+import uk.gov.ida.saml.core.domain.IpAddress;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 import uk.gov.ida.saml.core.domain.SimpleMdsValue;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
-import uk.gov.ida.saml.core.test.builders.SimpleMdsValueBuilder;
 import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
 import uk.gov.ida.saml.hub.factories.AttributeFactory;
+import uk.gov.ida.saml.idp.builders.MatchingDatasetBuilder;
+import uk.gov.ida.saml.idp.builders.SimpleMdsValueBuilder;
 import uk.gov.ida.saml.idp.stub.transformers.outbound.IdentityProviderAssertionToAssertionTransformer;
 import uk.gov.ida.saml.idp.stub.transformers.outbound.IdentityProviderAuthnStatementToAuthnStatementTransformer;
 
@@ -36,10 +37,9 @@ import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.idp.builders.IdentityProviderAuthnStatementBuilder.anIdentityProviderAuthnStatement;
 import static uk.gov.ida.saml.idp.test.builders.IPAddressAttributeBuilder.anIPAddress;
 import static uk.gov.ida.saml.idp.test.builders.IdentityProviderAssertionBuilder.anIdentityProviderAssertion;
-import static uk.gov.ida.saml.core.test.builders.IdentityProviderAuthnStatementBuilder.anIdentityProviderAuthnStatement;
-import static uk.gov.ida.saml.core.test.builders.IpAddressBuilder.anIpAddress;
 
 @RunWith(OpenSAMLMockitoRunner.class)
 public class IdentityProviderAssertionToAssertionTransformerTest {
@@ -79,7 +79,8 @@ public class IdentityProviderAssertionToAssertionTransformerTest {
     @Test
     public void transform_shouldTransformAssertionSubjectsFirstName() throws Exception {
         SimpleMdsValue<String> firstname = SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("Bob").build();
-        IdentityProviderAssertion assertion = anIdentityProviderAssertion().withMatchingDataset(MatchingDatasetBuilder.aMatchingDataset().addFirstname(firstname).build()).build();
+        IdentityProviderAssertion assertion = anIdentityProviderAssertion().withMatchingDataset(
+                MatchingDatasetBuilder.aMatchingDataset().addFirstname(firstname).build()).build();
 
         transformer.transform(assertion);
 
@@ -311,7 +312,7 @@ public class IdentityProviderAssertionToAssertionTransformerTest {
     public void transform_shouldTransformIpAddress() throws Exception {
         String ipAddressValue = "9.9.8.8";
         IdentityProviderAssertion assertion = anIdentityProviderAssertion()
-                .withAuthnStatement(anIdentityProviderAuthnStatement().withUserIpAddress(anIpAddress().withValue(ipAddressValue).build()).build())
+                .withAuthnStatement(anIdentityProviderAuthnStatement().withUserIpAddress(new IpAddress(ipAddressValue)).build())
                 .build();
         final Attribute attribute = anIPAddress().withValue("4.5.6.7").build();
         when(attributeFactory.createUserIpAddressAttribute(ipAddressValue)).thenReturn(attribute);

--- a/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/stub/tranformers/outbound/IdentityProviderAuthnStatementToAuthnStatementTransformerTest.java
+++ b/stub-idp-saml/src/test/java/uk/gov/ida/saml/idp/stub/tranformers/outbound/IdentityProviderAuthnStatementToAuthnStatementTransformerTest.java
@@ -1,5 +1,9 @@
 package uk.gov.ida.saml.idp.stub.tranformers.outbound;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.jodatime.api.Assertions.assertThat;
+import static uk.gov.ida.saml.idp.builders.IdentityProviderAuthnStatementBuilder.anIdentityProviderAuthnStatement;
+
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -13,10 +17,6 @@ import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
 import uk.gov.ida.saml.core.test.OpenSAMLRunner;
 import uk.gov.ida.saml.idp.stub.transformers.outbound.IdentityProviderAuthnStatementToAuthnStatementTransformer;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.jodatime.api.Assertions.assertThat;
-import static uk.gov.ida.saml.core.test.builders.IdentityProviderAuthnStatementBuilder.anIdentityProviderAuthnStatement;
 
 @RunWith(OpenSAMLRunner.class)
 public class IdentityProviderAuthnStatementToAuthnStatementTransformerTest {


### PR DESCRIPTION
- saml-domain-objects is no more, so remove its dependency.
- switch to Java optionals instead of Google optionals.
- update saml-utils.

Author: @vixus0